### PR TITLE
Fix project submission issues

### DIFF
--- a/cli-submit.js
+++ b/cli-submit.js
@@ -95,17 +95,18 @@ class ClaudeCreationsCLI {
     }
 
     async submitProject(projectData) {
-        if (!this.config.token) {
+        if (!this.config.token || !this.config.user) {
             console.error('❌ Not logged in. Run: claude-submit login');
             return false;
         }
+
+        projectData.creator_name = this.config.user.username;
 
         try {
             const response = await fetch(`${API_BASE}/projects`, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${this.config.token}`
+                    'Content-Type': 'application/json'
                 },
                 body: JSON.stringify(projectData)
             });

--- a/public/index.html
+++ b/public/index.html
@@ -554,10 +554,10 @@
                 <div class="code-block">
 curl -X POST https://claude-creations.vercel.app/api/projects \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{
+    "creator_name": "your_username",
     "title": "My Claude Code Project",
-    "description": "Built with Claude Code...",
+    "description": "A new project created via curl.",
     "github_url": "https://github.com/user/repo",
     "tags": "automation,api,claude-code",
     "category": "tools"


### PR DESCRIPTION
This commit fixes the project submission functionality for both CLI and cURL methods.

The key changes are:
- `cli-submit.js` now includes the `creator_name` in the submission payload, which is a required field by the backend.
- The example `curl` command in `public/index.html` has been updated to include the `creator_name` field, ensuring it's a valid request.
- The unnecessary and confusing `Authorization` header has been removed from `cli-submit.js` and the `curl` example, as the project submission endpoint is public.